### PR TITLE
Fix URL

### DIFF
--- a/api/KeyAuth.hpp
+++ b/api/KeyAuth.hpp
@@ -497,7 +497,7 @@ namespace KeyAuth {
 
 			std::string to_return;
 
-			curl_easy_setopt(curl, CURLOPT_URL, XorStr("https://keyauth.business/1.0/").c_str());
+			curl_easy_setopt(curl, CURLOPT_URL, XorStr("https://keyauth.win/api/1.0/").c_str());
 
 			curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
 			curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);


### PR DESCRIPTION
Old URL redirects to keyauth.win. By default curl doesn't follow redirect, so you need to update the URL in order for it to work.